### PR TITLE
feat: add dato to list of allowed next/image domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,4 +3,9 @@ const withHashicorp = require('@hashicorp/platform-nextjs-plugin')
 module.exports = withHashicorp({
   dato: { token: 'dc45ff8c8b27dd22a7c24aaaf8aa75' },
   nextOptimizedImages: true,
-})()
+})({
+  images: {
+    domains: ['www.datocms-assets.com'],
+    disableStaticImages: true,
+  },
+})


### PR DESCRIPTION
Adds datocms to the list of allowed domains for use with `next/image`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202123809197027