### PR TITLE
fix: force swc transforms

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,4 +8,10 @@ module.exports = withHashicorp({
 		domains: ['www.datocms-assets.com'],
 		disableStaticImages: true,
 	},
+	experimental: {
+		// We need to force Next to use SWC since otherwise it will pick up the
+		// babel.config.js file that we use for Jest, which isn't configured to
+		// support JSX.
+		forceSwcTransforms: true,
+	},
 })


### PR DESCRIPTION
We need to force Next to use SWC since otherwise it will pick up the `babel.config.js` file that we use for Jest, which isn't configured to support JSX.