### PR TITLE
cleanup: run prettier

### DIFF
--- a/components/button/style.module.css
+++ b/components/button/style.module.css
@@ -1,16 +1,16 @@
 .root {
-  background: var(--brand);
-  color: white;
-  border-radius: 999px;
-  padding: 10px 22px;
-  font-weight: 700;
-  text-transform: uppercase;
-  border: 0;
-  display: inline-block;
-  transition: background 0.25s ease;
-  margin: 25px 0; /* normally this would not be here */
+	background: var(--brand);
+	color: white;
+	border-radius: 999px;
+	padding: 10px 22px;
+	font-weight: 700;
+	text-transform: uppercase;
+	border: 0;
+	display: inline-block;
+	transition: background 0.25s ease;
+	margin: 25px 0; /* normally this would not be here */
 
-  &:hover {
-    background: #3c7dff;
-  }
+	&:hover {
+		background: #3c7dff;
+	}
 }

--- a/data/nav-data.json
+++ b/data/nav-data.json
@@ -1,589 +1,589 @@
 {
-  "infrastructureProducts": [
-    {
-      "url": "https://www.hashicorp.com/products/terraform",
-      "product": "Terraform",
-      "badge": ""
-    },
-    { "url": "https://www.packer.io/", "product": "Packer", "badge": "" }
-  ],
-  "securityProducts": [
-    {
-      "url": "https://www.hashicorp.com/products/vault",
-      "product": "Vault",
-      "badge": ""
-    },
-    {
-      "url": "https://boundaryproject.io/",
-      "product": "Boundary",
-      "badge": ""
-    }
-  ],
-  "networkingProducts": [
-    {
-      "url": "https://www.hashicorp.com/products/consul",
-      "product": "Consul",
-      "badge": ""
-    }
-  ],
-  "applicationProducts": [
-    {
-      "url": "https://www.hashicorp.com/products/nomad",
-      "product": "Nomad",
-      "badge": ""
-    },
-    {
-      "url": "https://waypointproject.io/",
-      "product": "Waypoint",
-      "badge": ""
-    },
-    { "url": "https://www.vagrantup.com/", "product": "Vagrant", "badge": "" }
-  ],
-  "hcpDescription": "A fully managed platform to automate infrastructure on any cloud with HashiCorp products.",
-  "hcpProducts": [
-    {
-      "url": "https://cloud.hashicorp.com/products/terraform",
-      "product": "Terraform Cloud",
-      "badge": ""
-    },
-    {
-      "url": "https://cloud.hashicorp.com/products/vault",
-      "product": "Vault",
-      "badge": ""
-    },
-    {
-      "url": "https://cloud.hashicorp.com/products/consul",
-      "product": "Consul",
-      "badge": ""
-    },
-    {
-      "url": "https://cloud.hashicorp.com/products/packer",
-      "product": "Packer",
-      "badge": ""
-    }
-  ],
-  "hcpCta": [
-    {
-      "title": "Visit cloud.hashicorp.com",
-      "url": "https://cloud.hashicorp.com/"
-    }
-  ],
-  "productsPromos": [
-    {
-      "image": {
-        "url": "https://www.datocms-assets.com/2885/1627426365-hcp.jpg",
-        "alt": "HashiCorp Cloud Platform cube",
-        "format": "jpg"
-      },
-      "linkUrl": "https://cloud.hashicorp.com/?utm_source=www&utm_content=product_main_nav",
-      "linkTitle": "Sign Up",
-      "theme": "brand",
-      "title": "Claim a $50 credit for HCP Vault or HCP Consul"
-    }
-  ],
-  "solutionsNav": [
-    {
-      "title": "Solutions",
-      "navItems": [
-        {
-          "title": "The Cloud Operating Model",
-          "url": "/cloud-operating-model",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Infrastructure provisioning",
-          "url": "/solutions/infrastructure-provisioning",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Network infrastructure automation",
-          "url": "/solutions/network-infrastructure-automation",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Cost optimization",
-          "url": "/solutions/optimize-cloud-spending",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Cloud migration",
-          "url": "/solutions/cloud-migration",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Cloud system of record",
-          "url": "/solutions/cloud-system-of-record",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Zero trust security",
-          "url": "/solutions/zero-trust-security",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Credential rotation",
-          "url": "/solutions/credential-rotation",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Encryption everywhere",
-          "url": "/solutions/encryption-everywhere",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Auditing & compliance",
-          "url": "/solutions/auditing-and-compliance",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Application delivery",
-          "url": "/solutions/modern-application-delivery",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Application networking",
-          "url": "/solutions/application-networking",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Workload orchestration",
-          "url": "/solutions/workload-orchestration",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Edge computing",
-          "url": "/solutions/edge-computing",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Kubernetes at scale",
-          "url": "/solutions/kubernetes-at-scale",
-          "badge": "",
-          "external": false
-        }
-      ],
-      "navCta": []
-    },
-    {
-      "title": "Customer Stories",
-      "navItems": [
-        {
-          "title": "ABN AMRO",
-          "url": "/case-studies/abn-amro",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Cruise",
-          "url": "/case-studies/cruise",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Github",
-          "url": "/case-studies/github",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Mercedes-Benz",
-          "url": "/case-studies/mercedes",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Pandora",
-          "url": "/case-studies/pandora",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Roblox",
-          "url": "/case-studies/roblox",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Ubisoft",
-          "url": "/case-studies/ubisoft",
-          "badge": "",
-          "external": false
-        }
-      ],
-      "navCta": [
-        { "title": "View all customer stories", "url": "/case-studies" }
-      ]
-    },
-    {
-      "title": "Industries",
-      "navItems": [
-        {
-          "title": "Financial services",
-          "url": "/industries/financial-services",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Healthcare",
-          "url": "/industries/healthcare",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Manufacturing",
-          "url": "/industries/manufacturing",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Media and entertainment",
-          "url": "/industries/media-and-entertainment",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Public sector",
-          "url": "/industries/public-sector",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Retail",
-          "url": "/industries/retail",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Technology",
-          "url": "/industries/technology",
-          "badge": "",
-          "external": false
-        }
-      ],
-      "navCta": [{ "title": "Contact sales", "url": "/contact-sales" }]
-    }
-  ],
-  "solutionsPromos": [],
-  "companyNav": [
-    {
-      "title": "Company",
-      "navItems": [
-        {
-          "title": "About us",
-          "url": "/about",
-          "badge": "",
-          "external": false
-        },
-        { "title": "Jobs", "url": "/jobs", "badge": "", "external": false },
-        {
-          "title": "Our principles",
-          "url": "/our-principles",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Tao of HashiCorp",
-          "url": "/tao-of-hashicorp",
-          "badge": "",
-          "external": false
-        },
-        { "title": "Blog", "url": "/blog", "badge": "", "external": false },
-        { "title": "Press", "url": "/press", "badge": "", "external": false },
-        {
-          "title": "Investors",
-          "url": "https://ir.hashicorp.com/",
-          "badge": "New",
-          "external": false
-        },
-        {
-          "title": "Contact us",
-          "url": "/contact",
-          "badge": "",
-          "external": false
-        }
-      ],
-      "navCta": [{ "title": "We're hiring", "url": "/jobs" }]
-    },
-    {
-      "title": "Events",
-      "navItems": [
-        {
-          "title": "HashiConf",
-          "url": "https://hashiconf.com/",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Webinars",
-          "url": "/events?type=webinar",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Workshops",
-          "url": "/events?type=workshop",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "View all events",
-          "url": "/events?type=all",
-          "badge": "",
-          "external": false
-        }
-      ],
-      "navCta": []
-    }
-  ],
-  "companyPromos": [
-    {
-      "image": {
-        "url": "https://www.datocms-assets.com/2885/1639599753-investor-relations-nav.jpg",
-        "alt": "HashiCorp Investor Relations",
-        "format": "jpg"
-      },
-      "linkUrl": "https://ir.hashicorp.com",
-      "linkTitle": "View Investor Relations",
-      "theme": "default",
-      "title": "HashiCorp shares have begun trading on the Nasdaq"
-    },
-    {
-      "image": {
-        "url": "https://www.datocms-assets.com/2885/1627425842-webinars-workshops.jpg",
-        "alt": "A group of audience members",
-        "format": "jpg"
-      },
-      "linkUrl": "https://www.hashicorp.com/events?utm_source=www&utm_content=company_main_nav",
-      "linkTitle": "Explore events",
-      "theme": "default",
-      "title": "Discover our latest Webinars and Workshops"
-    }
-  ],
-  "learnNav": [
-    {
-      "title": "Resources",
-      "navItems": [
-        { "title": "Blog", "url": "/blog", "badge": "", "external": false },
-        {
-          "title": "Case Studies",
-          "url": "/resources?type=case-study",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Webinars",
-          "url": "/resources?type=webinar",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Whitepapers",
-          "url": "/resources?type=white-paper",
-          "badge": "",
-          "external": false
-        }
-      ],
-      "navCta": [{ "title": "Resource Library", "url": "/resources" }]
-    },
-    {
-      "title": "",
-      "navItems": [
-        {
-          "title": "Certifications",
-          "url": "/certification",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Community",
-          "url": "/community",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Forum",
-          "url": "https://discuss.hashicorp.com/",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Demos",
-          "url": "/resources?type=demo",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Training",
-          "url": "/training",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Tutorials",
-          "url": "https://learn.hashicorp.com/",
-          "badge": "",
-          "external": false
-        }
-      ],
-      "navCta": []
-    },
-    {
-      "title": "Docs",
-      "navItems": [
-        {
-          "title": "Terraform",
-          "url": "https://www.terraform.io/docs/index.html",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Vault",
-          "url": "https://www.vaultproject.io/docs",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Consul",
-          "url": "https://www.consul.io/docs/index.html",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Nomad",
-          "url": "https://www.nomadproject.io/docs",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Vagrant",
-          "url": "https://www.vagrantup.com/docs",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Packer",
-          "url": "https://www.packer.io/docs",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Boundary",
-          "url": "https://boundaryproject.io/docs",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Waypoint",
-          "url": "https://waypointproject.io/docs",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Sentinel",
-          "url": "https://docs.hashicorp.com/sentinel",
-          "badge": "",
-          "external": true
-        }
-      ],
-      "navCta": []
-    }
-  ],
-  "learnPromos": [
-    {
-      "image": {
-        "url": "https://www.datocms-assets.com/2885/1627578888-learn.jpg",
-        "alt": "HashiCorp Learn",
-        "format": "jpg"
-      },
-      "linkUrl": "https://learn.hashicorp.com/?utm_source=www&utm_content=resources_main_nav",
-      "linkTitle": "View tutorials",
-      "theme": "light",
-      "title": "Learn HashiCorp tools with self-guided tutorials, videos, and hands-on labs."
-    }
-  ],
-  "supportNav": [
-    {
-      "title": "Customer Success",
-      "navItems": [
-        {
-          "title": "Overview",
-          "url": "/customer-success",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "Professional Services",
-          "url": "/customer-success/professional-services",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "HashiCorp Enterprise Academy",
-          "url": "/customer-success/enterprise-academy",
-          "badge": "",
-          "external": false
-        }
-      ],
-      "navCta": [
-        { "title": "Support Portal", "url": "https://support.hashicorp.com/" }
-      ]
-    },
-    {
-      "title": "Support",
-      "navItems": [
-        {
-          "title": "Submit a request",
-          "url": "https://support.hashicorp.com/hc/en-us/requests/new",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Enterprise Support Plan",
-          "url": "/customer-success/enterprise-support",
-          "badge": "",
-          "external": false
-        },
-        {
-          "title": "System Status",
-          "url": "https://status.hashicorp.com/",
-          "badge": "",
-          "external": true
-        },
-        {
-          "title": "Services and policies",
-          "url": "/technical-support-services-and-policies",
-          "badge": "",
-          "external": false
-        }
-      ],
-      "navCta": []
-    }
-  ],
-  "supportPromos": [
-    {
-      "image": {
-        "url": "https://www.datocms-assets.com/2885/1620077090-hashicorp-stack-promo.png",
-        "alt": "Hashicorp Stack",
-        "format": "png"
-      },
-      "linkUrl": "/cloud-operating-model?utm_source=www&utm_content=success_main_nav",
-      "linkTitle": "Read the whitepaper",
-      "theme": "brand",
-      "title": "Unlocking the Cloud Operating Model: Thrive in an era of multi-cloud architecture"
-    }
-  ]
+	"infrastructureProducts": [
+		{
+			"url": "https://www.hashicorp.com/products/terraform",
+			"product": "Terraform",
+			"badge": ""
+		},
+		{ "url": "https://www.packer.io/", "product": "Packer", "badge": "" }
+	],
+	"securityProducts": [
+		{
+			"url": "https://www.hashicorp.com/products/vault",
+			"product": "Vault",
+			"badge": ""
+		},
+		{
+			"url": "https://boundaryproject.io/",
+			"product": "Boundary",
+			"badge": ""
+		}
+	],
+	"networkingProducts": [
+		{
+			"url": "https://www.hashicorp.com/products/consul",
+			"product": "Consul",
+			"badge": ""
+		}
+	],
+	"applicationProducts": [
+		{
+			"url": "https://www.hashicorp.com/products/nomad",
+			"product": "Nomad",
+			"badge": ""
+		},
+		{
+			"url": "https://waypointproject.io/",
+			"product": "Waypoint",
+			"badge": ""
+		},
+		{ "url": "https://www.vagrantup.com/", "product": "Vagrant", "badge": "" }
+	],
+	"hcpDescription": "A fully managed platform to automate infrastructure on any cloud with HashiCorp products.",
+	"hcpProducts": [
+		{
+			"url": "https://cloud.hashicorp.com/products/terraform",
+			"product": "Terraform Cloud",
+			"badge": ""
+		},
+		{
+			"url": "https://cloud.hashicorp.com/products/vault",
+			"product": "Vault",
+			"badge": ""
+		},
+		{
+			"url": "https://cloud.hashicorp.com/products/consul",
+			"product": "Consul",
+			"badge": ""
+		},
+		{
+			"url": "https://cloud.hashicorp.com/products/packer",
+			"product": "Packer",
+			"badge": ""
+		}
+	],
+	"hcpCta": [
+		{
+			"title": "Visit cloud.hashicorp.com",
+			"url": "https://cloud.hashicorp.com/"
+		}
+	],
+	"productsPromos": [
+		{
+			"image": {
+				"url": "https://www.datocms-assets.com/2885/1627426365-hcp.jpg",
+				"alt": "HashiCorp Cloud Platform cube",
+				"format": "jpg"
+			},
+			"linkUrl": "https://cloud.hashicorp.com/?utm_source=www&utm_content=product_main_nav",
+			"linkTitle": "Sign Up",
+			"theme": "brand",
+			"title": "Claim a $50 credit for HCP Vault or HCP Consul"
+		}
+	],
+	"solutionsNav": [
+		{
+			"title": "Solutions",
+			"navItems": [
+				{
+					"title": "The Cloud Operating Model",
+					"url": "/cloud-operating-model",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Infrastructure provisioning",
+					"url": "/solutions/infrastructure-provisioning",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Network infrastructure automation",
+					"url": "/solutions/network-infrastructure-automation",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Cost optimization",
+					"url": "/solutions/optimize-cloud-spending",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Cloud migration",
+					"url": "/solutions/cloud-migration",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Cloud system of record",
+					"url": "/solutions/cloud-system-of-record",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Zero trust security",
+					"url": "/solutions/zero-trust-security",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Credential rotation",
+					"url": "/solutions/credential-rotation",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Encryption everywhere",
+					"url": "/solutions/encryption-everywhere",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Auditing & compliance",
+					"url": "/solutions/auditing-and-compliance",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Application delivery",
+					"url": "/solutions/modern-application-delivery",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Application networking",
+					"url": "/solutions/application-networking",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Workload orchestration",
+					"url": "/solutions/workload-orchestration",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Edge computing",
+					"url": "/solutions/edge-computing",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Kubernetes at scale",
+					"url": "/solutions/kubernetes-at-scale",
+					"badge": "",
+					"external": false
+				}
+			],
+			"navCta": []
+		},
+		{
+			"title": "Customer Stories",
+			"navItems": [
+				{
+					"title": "ABN AMRO",
+					"url": "/case-studies/abn-amro",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Cruise",
+					"url": "/case-studies/cruise",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Github",
+					"url": "/case-studies/github",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Mercedes-Benz",
+					"url": "/case-studies/mercedes",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Pandora",
+					"url": "/case-studies/pandora",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Roblox",
+					"url": "/case-studies/roblox",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Ubisoft",
+					"url": "/case-studies/ubisoft",
+					"badge": "",
+					"external": false
+				}
+			],
+			"navCta": [
+				{ "title": "View all customer stories", "url": "/case-studies" }
+			]
+		},
+		{
+			"title": "Industries",
+			"navItems": [
+				{
+					"title": "Financial services",
+					"url": "/industries/financial-services",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Healthcare",
+					"url": "/industries/healthcare",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Manufacturing",
+					"url": "/industries/manufacturing",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Media and entertainment",
+					"url": "/industries/media-and-entertainment",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Public sector",
+					"url": "/industries/public-sector",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Retail",
+					"url": "/industries/retail",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Technology",
+					"url": "/industries/technology",
+					"badge": "",
+					"external": false
+				}
+			],
+			"navCta": [{ "title": "Contact sales", "url": "/contact-sales" }]
+		}
+	],
+	"solutionsPromos": [],
+	"companyNav": [
+		{
+			"title": "Company",
+			"navItems": [
+				{
+					"title": "About us",
+					"url": "/about",
+					"badge": "",
+					"external": false
+				},
+				{ "title": "Jobs", "url": "/jobs", "badge": "", "external": false },
+				{
+					"title": "Our principles",
+					"url": "/our-principles",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Tao of HashiCorp",
+					"url": "/tao-of-hashicorp",
+					"badge": "",
+					"external": false
+				},
+				{ "title": "Blog", "url": "/blog", "badge": "", "external": false },
+				{ "title": "Press", "url": "/press", "badge": "", "external": false },
+				{
+					"title": "Investors",
+					"url": "https://ir.hashicorp.com/",
+					"badge": "New",
+					"external": false
+				},
+				{
+					"title": "Contact us",
+					"url": "/contact",
+					"badge": "",
+					"external": false
+				}
+			],
+			"navCta": [{ "title": "We're hiring", "url": "/jobs" }]
+		},
+		{
+			"title": "Events",
+			"navItems": [
+				{
+					"title": "HashiConf",
+					"url": "https://hashiconf.com/",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Webinars",
+					"url": "/events?type=webinar",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Workshops",
+					"url": "/events?type=workshop",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "View all events",
+					"url": "/events?type=all",
+					"badge": "",
+					"external": false
+				}
+			],
+			"navCta": []
+		}
+	],
+	"companyPromos": [
+		{
+			"image": {
+				"url": "https://www.datocms-assets.com/2885/1639599753-investor-relations-nav.jpg",
+				"alt": "HashiCorp Investor Relations",
+				"format": "jpg"
+			},
+			"linkUrl": "https://ir.hashicorp.com",
+			"linkTitle": "View Investor Relations",
+			"theme": "default",
+			"title": "HashiCorp shares have begun trading on the Nasdaq"
+		},
+		{
+			"image": {
+				"url": "https://www.datocms-assets.com/2885/1627425842-webinars-workshops.jpg",
+				"alt": "A group of audience members",
+				"format": "jpg"
+			},
+			"linkUrl": "https://www.hashicorp.com/events?utm_source=www&utm_content=company_main_nav",
+			"linkTitle": "Explore events",
+			"theme": "default",
+			"title": "Discover our latest Webinars and Workshops"
+		}
+	],
+	"learnNav": [
+		{
+			"title": "Resources",
+			"navItems": [
+				{ "title": "Blog", "url": "/blog", "badge": "", "external": false },
+				{
+					"title": "Case Studies",
+					"url": "/resources?type=case-study",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Webinars",
+					"url": "/resources?type=webinar",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Whitepapers",
+					"url": "/resources?type=white-paper",
+					"badge": "",
+					"external": false
+				}
+			],
+			"navCta": [{ "title": "Resource Library", "url": "/resources" }]
+		},
+		{
+			"title": "",
+			"navItems": [
+				{
+					"title": "Certifications",
+					"url": "/certification",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Community",
+					"url": "/community",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Forum",
+					"url": "https://discuss.hashicorp.com/",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Demos",
+					"url": "/resources?type=demo",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Training",
+					"url": "/training",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Tutorials",
+					"url": "https://learn.hashicorp.com/",
+					"badge": "",
+					"external": false
+				}
+			],
+			"navCta": []
+		},
+		{
+			"title": "Docs",
+			"navItems": [
+				{
+					"title": "Terraform",
+					"url": "https://www.terraform.io/docs/index.html",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Vault",
+					"url": "https://www.vaultproject.io/docs",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Consul",
+					"url": "https://www.consul.io/docs/index.html",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Nomad",
+					"url": "https://www.nomadproject.io/docs",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Vagrant",
+					"url": "https://www.vagrantup.com/docs",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Packer",
+					"url": "https://www.packer.io/docs",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Boundary",
+					"url": "https://boundaryproject.io/docs",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Waypoint",
+					"url": "https://waypointproject.io/docs",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Sentinel",
+					"url": "https://docs.hashicorp.com/sentinel",
+					"badge": "",
+					"external": true
+				}
+			],
+			"navCta": []
+		}
+	],
+	"learnPromos": [
+		{
+			"image": {
+				"url": "https://www.datocms-assets.com/2885/1627578888-learn.jpg",
+				"alt": "HashiCorp Learn",
+				"format": "jpg"
+			},
+			"linkUrl": "https://learn.hashicorp.com/?utm_source=www&utm_content=resources_main_nav",
+			"linkTitle": "View tutorials",
+			"theme": "light",
+			"title": "Learn HashiCorp tools with self-guided tutorials, videos, and hands-on labs."
+		}
+	],
+	"supportNav": [
+		{
+			"title": "Customer Success",
+			"navItems": [
+				{
+					"title": "Overview",
+					"url": "/customer-success",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "Professional Services",
+					"url": "/customer-success/professional-services",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "HashiCorp Enterprise Academy",
+					"url": "/customer-success/enterprise-academy",
+					"badge": "",
+					"external": false
+				}
+			],
+			"navCta": [
+				{ "title": "Support Portal", "url": "https://support.hashicorp.com/" }
+			]
+		},
+		{
+			"title": "Support",
+			"navItems": [
+				{
+					"title": "Submit a request",
+					"url": "https://support.hashicorp.com/hc/en-us/requests/new",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Enterprise Support Plan",
+					"url": "/customer-success/enterprise-support",
+					"badge": "",
+					"external": false
+				},
+				{
+					"title": "System Status",
+					"url": "https://status.hashicorp.com/",
+					"badge": "",
+					"external": true
+				},
+				{
+					"title": "Services and policies",
+					"url": "/technical-support-services-and-policies",
+					"badge": "",
+					"external": false
+				}
+			],
+			"navCta": []
+		}
+	],
+	"supportPromos": [
+		{
+			"image": {
+				"url": "https://www.datocms-assets.com/2885/1620077090-hashicorp-stack-promo.png",
+				"alt": "Hashicorp Stack",
+				"format": "png"
+			},
+			"linkUrl": "/cloud-operating-model?utm_source=www&utm_content=success_main_nav",
+			"linkTitle": "Read the whitepaper",
+			"theme": "brand",
+			"title": "Unlocking the Cloud Operating Model: Thrive in an era of multi-cloud architecture"
+		}
+	]
 }

--- a/layouts/base/components/nav/fragment.graphql
+++ b/layouts/base/components/nav/fragment.graphql
@@ -1,79 +1,79 @@
 fragment navFields on NavRecord {
-  infrastructureProducts {
-    ...product
-  }
-  securityProducts {
-    ...product
-  }
-  networkingProducts {
-    ...product
-  }
-  applicationProducts {
-    ...product
-  }
-  hcpDescription
-  hcpProducts {
-    ...product
-  }
-  hcpCta {
-    title
-    url
-  }
-  productsPromos {
-    ...internal_Promos
-  }
-  solutionsNav {
-    ...nav_item
-  }
-  solutionsPromos {
-    ...internal_Promos
-  }
-  companyNav {
-    ...nav_item
-  }
-  companyPromos {
-    ...internal_Promos
-  }
-  learnNav {
-    ...nav_item
-  }
-  learnPromos {
-    ...internal_Promos
-  }
-  supportNav {
-    ...nav_item
-  }
-  supportPromos {
-    ...internal_Promos
-  }
+	infrastructureProducts {
+		...product
+	}
+	securityProducts {
+		...product
+	}
+	networkingProducts {
+		...product
+	}
+	applicationProducts {
+		...product
+	}
+	hcpDescription
+	hcpProducts {
+		...product
+	}
+	hcpCta {
+		title
+		url
+	}
+	productsPromos {
+		...internal_Promos
+	}
+	solutionsNav {
+		...nav_item
+	}
+	solutionsPromos {
+		...internal_Promos
+	}
+	companyNav {
+		...nav_item
+	}
+	companyPromos {
+		...internal_Promos
+	}
+	learnNav {
+		...nav_item
+	}
+	learnPromos {
+		...internal_Promos
+	}
+	supportNav {
+		...nav_item
+	}
+	supportPromos {
+		...internal_Promos
+	}
 }
 
 fragment product on NavProductRecord {
-  url
-  product
-  badge
+	url
+	product
+	badge
 }
 
 fragment nav_item on NavItemRecord {
-  title
-  navItems {
-    title
-    url
-    badge
-    external
-  }
-  navCta {
-    title
-    url
-  }
+	title
+	navItems {
+		title
+		url
+		badge
+		external
+	}
+	navCta {
+		title
+		url
+	}
 }
 
 fragment internal_Promos on NavPromoRecord {
-  image {
-    ...imageFields
-  }
-  linkUrl
-  linkTitle
-  theme
-  title
+	image {
+		...imageFields
+	}
+	linkUrl
+	linkTitle
+	theme
+	title
 }

--- a/layouts/base/components/nav/style.css
+++ b/layouts/base/components/nav/style.css
@@ -1,777 +1,777 @@
 @custom-media --desktop-viewport (min-width: 1200px);
 
 .g-nav {
-  background: var(--white);
-  border-bottom: 1px solid var(--gray-5);
-  color: var(--gray-1);
-  position: relative;
-  z-index: 666666667; /* higher than OptinMonster */
-
-  & .background {
-    background: var(--gray-1);
-    height: 100vh;
-    left: 0;
-    opacity: 0.8;
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: 1;
-  }
-
-  & .logo {
-    line-height: 1;
-
-    @media (--desktop-viewport) {
-      margin-right: 32px;
-    }
-
-    @media (min-width: 1100px) {
-      margin-right: 48px;
-    }
-
-    & svg {
-      height: 100%;
-      width: unset;
-    }
-
-    & .logo-desktop {
-      display: none;
-      height: 34px;
-
-      @media (--desktop-viewport) {
-        display: block;
-      }
-    }
-  }
-
-  & .logo-mobile {
-    align-items: center;
-    display: flex;
-    height: 38px;
-    justify-content: space-between;
-    line-height: 1;
-    margin-left: -4px;
-
-    @media (--desktop-viewport) {
-      display: none;
-    }
-
-    & span {
-      cursor: pointer;
-    }
-
-    & path {
-      fill: var(--black);
-    }
-  }
-
-  & nav {
-    align-items: center;
-    background: var(--white);
-    display: flex;
-    height: 64px;
-    justify-content: space-between;
-    padding: 0 24px;
-    position: relative;
-    z-index: 3;
-
-    @media (--medium-up) {
-      padding: 0 32px;
-    }
-
-    @media (--desktop-viewport) {
-      transition: none;
-      width: 100%;
-    }
-
-    &.active {
-      bottom: 0;
-      left: 0;
-      position: fixed;
-      right: 0;
-      top: 0;
-
-      @media (--desktop-viewport) {
-        position: relative;
-      }
-
-      & .mobile-toggle svg {
-        &:first-child {
-          display: none;
-        }
-
-        &:last-child {
-          display: block;
-        }
-      }
-
-      & .links {
-        opacity: 1;
-      }
-    }
-  }
-
-  & .mobile-toggle {
-    align-items: center;
-    background: none;
-    border: 0;
-    bottom: 0;
-    cursor: pointer;
-    display: flex;
-    line-height: 1;
-    padding: 0 24px;
-    position: absolute;
-    right: 0;
-    top: 0;
-
-    @media (min-width: --medium-up) {
-      padding: 0 32px;
-    }
-
-    @media (--desktop-viewport) {
-      display: none;
-    }
-
-    & svg:last-child {
-      display: none;
-    }
-  }
-
-  & :not(.active) .links {
-    @media not all and (--desktop-viewport) {
-      display: none;
-    }
-  }
-
-  & .links {
-    background: var(--white);
-    height: calc(100vh - 64px);
-    left: 0;
-    opacity: 0;
-    padding-bottom: 140px;
-    position: fixed;
-    top: 63px;
-    width: 100%;
-    z-index: 2;
-
-    @media (--desktop-viewport) {
-      display: flex;
-      font-size: 0.938rem;
-      height: auto;
-      justify-content: space-between;
-      line-height: 1.6em;
-      opacity: 1;
-      padding: 0;
-      position: static;
-    }
-
-    & > ul {
-      align-items: center;
-      list-style: none;
-      margin: 0;
-      padding: 0;
-
-      @media (--desktop-viewport) {
-        display: flex;
-      }
-
-      &:first-child {
-        flex-grow: 1;
-      }
-    }
-  }
-
-  /* NAV ITEMS */
-  & .nav-item {
-    align-items: center;
-    display: flex;
-    flex-shrink: 0;
-    justify-content: space-between;
-
-    @media (--desktop-viewport) {
-      border: none;
-      height: 100%;
-    }
-
-    &:not(.active) .panel {
-      opacity: 0;
-      visibility: hidden;
-
-      @media (--desktop-viewport) {
-        display: none;
-      }
-    }
-
-    &.active {
-      & > .link svg {
-        @media (--desktop-viewport) {
-          transform: rotate(-180deg);
-        }
-      }
-
-      & .panel {
-        left: 0;
-        opacity: 1;
-
-        & .breadcrumb {
-          left: 0;
-        }
-      }
-    }
-
-    &.learn {
-      & .promo {
-        display: none;
-
-        @media (min-width: 1160px) {
-          display: flex;
-        }
-      }
-    }
-
-    & + .nav-item {
-      @media (--desktop-viewport) {
-        margin-left: 32px;
-      }
-    }
-
-    & > a,
-    & > button {
-      color: inherit;
-    }
-
-    & > button {
-      background-color: transparent;
-      border-style: none;
-      cursor: pointer;
-      font: inherit;
-    }
-
-    & .link {
-      align-items: center;
-      display: flex;
-      justify-content: space-between;
-      padding: 6px 24px;
-      width: 100%;
-
-      @media (--desktop-viewport) {
-        padding: 0;
-      }
-
-      & > svg {
-        display: none;
-        transition: transform 0.3s;
-
-        @media (--desktop-viewport) {
-          margin: 2px 0 0 8px;
-        }
-
-        &:first-child {
-          @media (--desktop-viewport) {
-            display: block;
-          }
-        }
-
-        &:last-child {
-          display: block;
-
-          @media (--desktop-viewport) {
-            display: none;
-          }
-        }
-
-        & > path {
-          transition: stroke 0.3s;
-        }
-      }
-    }
-
-    /* PANELS */
-    & .panel {
-      background: var(--white);
-      bottom: 92px;
-      left: 20%;
-      overflow-x: hidden;
-      overflow-y: auto;
-      padding-bottom: 64px;
-      padding-top: 74px;
-      position: absolute;
-      right: 0;
-      top: 0;
-      transition: left 0.2s, opacity 0.2s, visibility 0.2s;
-      transition-timing-function: cubic-bezier(0.5, 0.2, 0.2, 0.5);
-      width: 100%;
-
-      @media (--desktop-viewport) {
-        border: 1px solid var(--gray-5);
-        left: 0;
-        min-height: 402px;
-        overflow: hidden;
-        padding: 24px 0 32px;
-        top: 64px;
-        transition: none;
-        z-index: 2;
-      }
-
-      & > .g-grid-container {
-        display: flex;
-
-        @media (--desktop-viewport) {
-          height: 100%;
-        }
-      }
-
-      & .cloud-partner-logos {
-        align-items: center;
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-between;
-
-        @media (--medium-up) {
-          align-items: center;
-        }
-
-        & li {
-          flex: 48% 0;
-
-          @media (--medium-up) {
-            flex: 1;
-          }
-
-          & + li {
-            @media (--medium-up) {
-              margin-left: 1rem;
-            }
-          }
-
-          &:nth-child(n + 3) {
-            margin-top: 1rem;
-
-            @media (--medium-up) {
-              margin-top: 0;
-            }
-          }
-        }
-
-        & .logo-container {
-          align-items: center;
-          border: 1px solid var(--gray-5);
-          display: flex;
-          height: 100px;
-          justify-content: center;
-          width: 100%;
-
-          & > svg {
-            margin: 0;
-            width: 100%;
-          }
-        }
-      }
-
-      & .breadcrumb {
-        align-items: center;
-        background: var(--white);
-        border-bottom: 1px solid var(--gray-5);
-        cursor: pointer;
-        display: flex;
-        left: 20%;
-        margin-bottom: 16px;
-        padding-bottom: 19px;
-        padding-top: 10px;
-        position: fixed;
-        top: 63px;
-        transition: left 0.2s cubic-bezier(0.5, 0.2, 0.2, 0.5);
-        width: 100%;
-        z-index: 1;
-
-        @media (--desktop-viewport) {
-          display: none;
-        }
-
-        & svg {
-          margin: 0 24px -1px 0;
-          transform: rotate(180deg);
-        }
-      }
-
-      & .panel-content {
-        padding-bottom: 32px;
-        position: relative;
-        width: 100%;
-
-        @media (--desktop-viewport) {
-          display: flex;
-          line-height: 24px;
-          margin-top: 16px;
-          padding: 0;
-        }
-
-        & .column {
-          position: relative;
-          display: flex;
-          flex: 0 1 auto;
-          flex-direction: column;
-          justify-content: flex-start;
-          min-width: 160px;
-          &.no-heading {
-            margin-top: 34px;
-          }
-          @media (--desktop-viewport) {
-            & + .column {
-              margin-left: 3rem;
-              & + .column {
-                flex: 1 1 auto;
-              }
-            }
-          }
-          &.divider {
-            flex: 1 1 75%;
-            @media (--desktop-viewport) {
-              margin-left: 6rem;
-              position: relative;
-              &::before {
-                background: var(--gray-5);
-                content: '';
-                height: 80%;
-                left: -4rem;
-                position: absolute;
-                top: 0;
-                width: 1px;
-              }
-            }
-          }
-          @media (--desktop-viewport) {
-            &.cloud-partner-column {
-              margin-left: 50px;
-            }
-          }
-
-          &.hcp {
-            & .product-list {
-              flex: 0;
-              margin: 20px 0;
-            }
-
-            & .footer {
-              position: unset;
-            }
-          }
-
-          &.solutions {
-            &:not(:first-child) {
-              @media (--desktop-viewport) {
-                margin-left: 6rem;
-              }
-            }
-
-            & .footer {
-              display: block;
-              position: inherit;
-
-              @media (width < 1200px) {
-                font-size: 17px;
-                margin-bottom: 1rem;
-                margin-top: 1rem;
-              }
-
-              & a {
-                display: block;
-
-                & > svg {
-                  margin: 2px 0 0 8px;
-                  transition: transform 0.35s;
-                }
-
-                &:hover > svg {
-                  transform: translateX(2px);
-                }
-              }
-            }
-
-            & .highlight,
-            & .com-link {
-              color: var(--brand-link);
-            }
-
-            & .contact-sales-link {
-              @media (width < 1200px) {
-                display: none;
-              }
-            }
-          }
-        }
-
-        & .eyebrow {
-          color: var(--gray-2);
-          display: block;
-          letter-spacing: 0.06em;
-          margin: 32px 0 12px;
-
-          @media (--desktop-viewport) {
-            color: inherit;
-            margin: 0 0 16px;
-          }
-        }
-
-        & .hcp-blurb {
-          color: var(--gray-3);
-          margin: 0;
-          max-width: 355px;
-        }
-
-        & ul {
-          list-style: none;
-          padding: 0;
-
-          &.product-list {
-            flex: 1 1 100%;
-
-            &.columns,
-            &.customer-stories {
-              @media (--desktop-viewport) {
-                column-gap: 48px;
-                display: inline-grid;
-                grid-auto-flow: column;
-                grid-template-columns: repeat(2, max-content);
-                grid-template-rows: repeat(9, 28px);
-              }
-            }
-          }
-
-          & li {
-            display: flex;
-
-            & .product-logo {
-              height: 20px;
-
-              & svg {
-                height: 100%;
-              }
-            }
-          }
-
-          & a {
-            align-items: center;
-            color: inherit;
-            display: flex;
-            padding: 6px 0;
-            position: relative;
-
-            @media (--desktop-viewport) {
-              padding: 2px 0;
-            }
-
-            &:hover {
-              text-decoration: underline;
-            }
-
-            & svg {
-              margin-right: 16px;
-              width: 20px;
-            }
-
-            & .badge {
-              background: var(--white);
-              border: 1px solid var(--gray-4);
-              border-radius: 2px;
-              color: var(--gray-3);
-              display: block;
-              font-family: var(--font-display);
-              font-size: 0.6875rem;
-              font-weight: 700;
-              left: calc(100% + 0.5rem);
-              letter-spacing: 0.08em;
-              line-height: 1.272727273em;
-              padding: 1.5px 4px 1.5px 6px;
-              position: absolute;
-              text-align: center;
-              text-transform: uppercase;
-              top: 12px;
-              white-space: nowrap;
-              @media (--desktop-viewport) {
-                top: 5px;
-              }
-
-              &.new {
-                background: var(--gray-2);
-                border-color: var(--gray-2);
-                color: var(--white);
-              }
-            }
-          }
-        }
-      }
-
-      & .footer {
-        display: none;
-
-        @media (--desktop-viewport) {
-          bottom: 0;
-          display: inline-block;
-          left: 0;
-          position: absolute;
-        }
-
-        & a {
-          align-items: center;
-          color: inherit;
-          display: inline-flex;
-          line-height: 1.75rem;
-          transition: color 0.35s ease;
-
-          &:hover svg {
-            transform: translateX(2px);
-          }
-
-          & + a {
-            margin-left: 50px;
-          }
-        }
-
-        & svg {
-          margin: 2px 0 0 8px;
-          transition: transform 0.35s;
-        }
-      }
-    }
-
-    /* PROMOS */
-    & .promo {
-      background: var(--gray-6);
-      color: inherit;
-      display: none;
-      flex-direction: column;
-      flex-shrink: 0;
-      height: 344px;
-      margin-left: 32px;
-      overflow: hidden;
-      position: relative;
-      width: 280px;
-
-      @media (--desktop-viewport) {
-        display: flex;
-      }
-
-      &:nth-of-type(2) {
-        display: none;
-
-        @media (min-width: 1000px) {
-          display: flex;
-        }
-      }
-
-      &:hover .callout {
-        text-decoration: underline;
-      }
-
-      &.theme-brand {
-        background: var(--brand-secondary);
-      }
-
-      &.theme-consul {
-        background: var(--consul-secondary);
-      }
-
-      &.theme-nomad {
-        background: var(--nomad-secondary);
-      }
-
-      &.theme-packer {
-        background: var(--packer-secondary);
-      }
-
-      &.theme-terraform {
-        background: var(--terraform-secondary);
-      }
-
-      &.theme-vagrant {
-        background: var(--vagrant-secondary);
-      }
-
-      &.theme-vault {
-        background: var(--vault-secondary);
-      }
-
-      & picture {
-        display: block;
-        flex-shrink: 0;
-        line-height: 0;
-      }
-
-      & img {
-        flex-shrink: 0;
-        width: 100%;
-      }
-
-      & .content {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-        justify-content: space-between;
-        padding: 22px 32px 32px;
-        position: relative;
-      }
-
-      & .title {
-        display: block;
-      }
-
-      & .callout {
-        bottom: 32px;
-        color: inherit;
-        line-height: 1.75rem;
-        position: absolute;
-      }
-    }
-  }
-
-  /* PRICING BUTTON */
-  & .pricing {
-    background: var(--gray-6);
-    bottom: 0;
-    left: 0;
-    padding: 24px;
-    position: fixed;
-    width: 100%;
-
-    @media (--desktop-viewport) {
-      background: none;
-      margin-left: 32px;
-      padding: 0;
-      position: static;
-    }
-
-    & a {
-      border: 1px solid #d2d2d3;
-      border-radius: 4px;
-      box-sizing: border-box;
-      color: inherit;
-      display: block;
-      padding: 7px 22px;
-      text-align: center;
-      text-decoration: none;
-      transition: background-color 0.15s ease, border 0.15s ease;
-      width: 100%;
-
-      @media (--desktop-viewport) {
-        width: auto;
-      }
-
-      &:hover,
-      &:active {
-        text-decoration: none;
-      }
-
-      &:focus,
-      &:hover {
-        background: #e8e8e9;
-        border-color: #e8e8e9;
-      }
-
-      &:active {
-        background: #dbdbdc;
-        border-color: #dbdbdc;
-      }
-    }
-  }
+	background: var(--white);
+	border-bottom: 1px solid var(--gray-5);
+	color: var(--gray-1);
+	position: relative;
+	z-index: 666666667; /* higher than OptinMonster */
+
+	& .background {
+		background: var(--gray-1);
+		height: 100vh;
+		left: 0;
+		opacity: 0.8;
+		position: absolute;
+		right: 0;
+		top: 0;
+		z-index: 1;
+	}
+
+	& .logo {
+		line-height: 1;
+
+		@media (--desktop-viewport) {
+			margin-right: 32px;
+		}
+
+		@media (min-width: 1100px) {
+			margin-right: 48px;
+		}
+
+		& svg {
+			height: 100%;
+			width: unset;
+		}
+
+		& .logo-desktop {
+			display: none;
+			height: 34px;
+
+			@media (--desktop-viewport) {
+				display: block;
+			}
+		}
+	}
+
+	& .logo-mobile {
+		align-items: center;
+		display: flex;
+		height: 38px;
+		justify-content: space-between;
+		line-height: 1;
+		margin-left: -4px;
+
+		@media (--desktop-viewport) {
+			display: none;
+		}
+
+		& span {
+			cursor: pointer;
+		}
+
+		& path {
+			fill: var(--black);
+		}
+	}
+
+	& nav {
+		align-items: center;
+		background: var(--white);
+		display: flex;
+		height: 64px;
+		justify-content: space-between;
+		padding: 0 24px;
+		position: relative;
+		z-index: 3;
+
+		@media (--medium-up) {
+			padding: 0 32px;
+		}
+
+		@media (--desktop-viewport) {
+			transition: none;
+			width: 100%;
+		}
+
+		&.active {
+			bottom: 0;
+			left: 0;
+			position: fixed;
+			right: 0;
+			top: 0;
+
+			@media (--desktop-viewport) {
+				position: relative;
+			}
+
+			& .mobile-toggle svg {
+				&:first-child {
+					display: none;
+				}
+
+				&:last-child {
+					display: block;
+				}
+			}
+
+			& .links {
+				opacity: 1;
+			}
+		}
+	}
+
+	& .mobile-toggle {
+		align-items: center;
+		background: none;
+		border: 0;
+		bottom: 0;
+		cursor: pointer;
+		display: flex;
+		line-height: 1;
+		padding: 0 24px;
+		position: absolute;
+		right: 0;
+		top: 0;
+
+		@media (min-width: --medium-up) {
+			padding: 0 32px;
+		}
+
+		@media (--desktop-viewport) {
+			display: none;
+		}
+
+		& svg:last-child {
+			display: none;
+		}
+	}
+
+	& :not(.active) .links {
+		@media not all and (--desktop-viewport) {
+			display: none;
+		}
+	}
+
+	& .links {
+		background: var(--white);
+		height: calc(100vh - 64px);
+		left: 0;
+		opacity: 0;
+		padding-bottom: 140px;
+		position: fixed;
+		top: 63px;
+		width: 100%;
+		z-index: 2;
+
+		@media (--desktop-viewport) {
+			display: flex;
+			font-size: 0.938rem;
+			height: auto;
+			justify-content: space-between;
+			line-height: 1.6em;
+			opacity: 1;
+			padding: 0;
+			position: static;
+		}
+
+		& > ul {
+			align-items: center;
+			list-style: none;
+			margin: 0;
+			padding: 0;
+
+			@media (--desktop-viewport) {
+				display: flex;
+			}
+
+			&:first-child {
+				flex-grow: 1;
+			}
+		}
+	}
+
+	/* NAV ITEMS */
+	& .nav-item {
+		align-items: center;
+		display: flex;
+		flex-shrink: 0;
+		justify-content: space-between;
+
+		@media (--desktop-viewport) {
+			border: none;
+			height: 100%;
+		}
+
+		&:not(.active) .panel {
+			opacity: 0;
+			visibility: hidden;
+
+			@media (--desktop-viewport) {
+				display: none;
+			}
+		}
+
+		&.active {
+			& > .link svg {
+				@media (--desktop-viewport) {
+					transform: rotate(-180deg);
+				}
+			}
+
+			& .panel {
+				left: 0;
+				opacity: 1;
+
+				& .breadcrumb {
+					left: 0;
+				}
+			}
+		}
+
+		&.learn {
+			& .promo {
+				display: none;
+
+				@media (min-width: 1160px) {
+					display: flex;
+				}
+			}
+		}
+
+		& + .nav-item {
+			@media (--desktop-viewport) {
+				margin-left: 32px;
+			}
+		}
+
+		& > a,
+		& > button {
+			color: inherit;
+		}
+
+		& > button {
+			background-color: transparent;
+			border-style: none;
+			cursor: pointer;
+			font: inherit;
+		}
+
+		& .link {
+			align-items: center;
+			display: flex;
+			justify-content: space-between;
+			padding: 6px 24px;
+			width: 100%;
+
+			@media (--desktop-viewport) {
+				padding: 0;
+			}
+
+			& > svg {
+				display: none;
+				transition: transform 0.3s;
+
+				@media (--desktop-viewport) {
+					margin: 2px 0 0 8px;
+				}
+
+				&:first-child {
+					@media (--desktop-viewport) {
+						display: block;
+					}
+				}
+
+				&:last-child {
+					display: block;
+
+					@media (--desktop-viewport) {
+						display: none;
+					}
+				}
+
+				& > path {
+					transition: stroke 0.3s;
+				}
+			}
+		}
+
+		/* PANELS */
+		& .panel {
+			background: var(--white);
+			bottom: 92px;
+			left: 20%;
+			overflow-x: hidden;
+			overflow-y: auto;
+			padding-bottom: 64px;
+			padding-top: 74px;
+			position: absolute;
+			right: 0;
+			top: 0;
+			transition: left 0.2s, opacity 0.2s, visibility 0.2s;
+			transition-timing-function: cubic-bezier(0.5, 0.2, 0.2, 0.5);
+			width: 100%;
+
+			@media (--desktop-viewport) {
+				border: 1px solid var(--gray-5);
+				left: 0;
+				min-height: 402px;
+				overflow: hidden;
+				padding: 24px 0 32px;
+				top: 64px;
+				transition: none;
+				z-index: 2;
+			}
+
+			& > .g-grid-container {
+				display: flex;
+
+				@media (--desktop-viewport) {
+					height: 100%;
+				}
+			}
+
+			& .cloud-partner-logos {
+				align-items: center;
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: space-between;
+
+				@media (--medium-up) {
+					align-items: center;
+				}
+
+				& li {
+					flex: 48% 0;
+
+					@media (--medium-up) {
+						flex: 1;
+					}
+
+					& + li {
+						@media (--medium-up) {
+							margin-left: 1rem;
+						}
+					}
+
+					&:nth-child(n + 3) {
+						margin-top: 1rem;
+
+						@media (--medium-up) {
+							margin-top: 0;
+						}
+					}
+				}
+
+				& .logo-container {
+					align-items: center;
+					border: 1px solid var(--gray-5);
+					display: flex;
+					height: 100px;
+					justify-content: center;
+					width: 100%;
+
+					& > svg {
+						margin: 0;
+						width: 100%;
+					}
+				}
+			}
+
+			& .breadcrumb {
+				align-items: center;
+				background: var(--white);
+				border-bottom: 1px solid var(--gray-5);
+				cursor: pointer;
+				display: flex;
+				left: 20%;
+				margin-bottom: 16px;
+				padding-bottom: 19px;
+				padding-top: 10px;
+				position: fixed;
+				top: 63px;
+				transition: left 0.2s cubic-bezier(0.5, 0.2, 0.2, 0.5);
+				width: 100%;
+				z-index: 1;
+
+				@media (--desktop-viewport) {
+					display: none;
+				}
+
+				& svg {
+					margin: 0 24px -1px 0;
+					transform: rotate(180deg);
+				}
+			}
+
+			& .panel-content {
+				padding-bottom: 32px;
+				position: relative;
+				width: 100%;
+
+				@media (--desktop-viewport) {
+					display: flex;
+					line-height: 24px;
+					margin-top: 16px;
+					padding: 0;
+				}
+
+				& .column {
+					position: relative;
+					display: flex;
+					flex: 0 1 auto;
+					flex-direction: column;
+					justify-content: flex-start;
+					min-width: 160px;
+					&.no-heading {
+						margin-top: 34px;
+					}
+					@media (--desktop-viewport) {
+						& + .column {
+							margin-left: 3rem;
+							& + .column {
+								flex: 1 1 auto;
+							}
+						}
+					}
+					&.divider {
+						flex: 1 1 75%;
+						@media (--desktop-viewport) {
+							margin-left: 6rem;
+							position: relative;
+							&::before {
+								background: var(--gray-5);
+								content: '';
+								height: 80%;
+								left: -4rem;
+								position: absolute;
+								top: 0;
+								width: 1px;
+							}
+						}
+					}
+					@media (--desktop-viewport) {
+						&.cloud-partner-column {
+							margin-left: 50px;
+						}
+					}
+
+					&.hcp {
+						& .product-list {
+							flex: 0;
+							margin: 20px 0;
+						}
+
+						& .footer {
+							position: unset;
+						}
+					}
+
+					&.solutions {
+						&:not(:first-child) {
+							@media (--desktop-viewport) {
+								margin-left: 6rem;
+							}
+						}
+
+						& .footer {
+							display: block;
+							position: inherit;
+
+							@media (width < 1200px) {
+								font-size: 17px;
+								margin-bottom: 1rem;
+								margin-top: 1rem;
+							}
+
+							& a {
+								display: block;
+
+								& > svg {
+									margin: 2px 0 0 8px;
+									transition: transform 0.35s;
+								}
+
+								&:hover > svg {
+									transform: translateX(2px);
+								}
+							}
+						}
+
+						& .highlight,
+						& .com-link {
+							color: var(--brand-link);
+						}
+
+						& .contact-sales-link {
+							@media (width < 1200px) {
+								display: none;
+							}
+						}
+					}
+				}
+
+				& .eyebrow {
+					color: var(--gray-2);
+					display: block;
+					letter-spacing: 0.06em;
+					margin: 32px 0 12px;
+
+					@media (--desktop-viewport) {
+						color: inherit;
+						margin: 0 0 16px;
+					}
+				}
+
+				& .hcp-blurb {
+					color: var(--gray-3);
+					margin: 0;
+					max-width: 355px;
+				}
+
+				& ul {
+					list-style: none;
+					padding: 0;
+
+					&.product-list {
+						flex: 1 1 100%;
+
+						&.columns,
+						&.customer-stories {
+							@media (--desktop-viewport) {
+								column-gap: 48px;
+								display: inline-grid;
+								grid-auto-flow: column;
+								grid-template-columns: repeat(2, max-content);
+								grid-template-rows: repeat(9, 28px);
+							}
+						}
+					}
+
+					& li {
+						display: flex;
+
+						& .product-logo {
+							height: 20px;
+
+							& svg {
+								height: 100%;
+							}
+						}
+					}
+
+					& a {
+						align-items: center;
+						color: inherit;
+						display: flex;
+						padding: 6px 0;
+						position: relative;
+
+						@media (--desktop-viewport) {
+							padding: 2px 0;
+						}
+
+						&:hover {
+							text-decoration: underline;
+						}
+
+						& svg {
+							margin-right: 16px;
+							width: 20px;
+						}
+
+						& .badge {
+							background: var(--white);
+							border: 1px solid var(--gray-4);
+							border-radius: 2px;
+							color: var(--gray-3);
+							display: block;
+							font-family: var(--font-display);
+							font-size: 0.6875rem;
+							font-weight: 700;
+							left: calc(100% + 0.5rem);
+							letter-spacing: 0.08em;
+							line-height: 1.272727273em;
+							padding: 1.5px 4px 1.5px 6px;
+							position: absolute;
+							text-align: center;
+							text-transform: uppercase;
+							top: 12px;
+							white-space: nowrap;
+							@media (--desktop-viewport) {
+								top: 5px;
+							}
+
+							&.new {
+								background: var(--gray-2);
+								border-color: var(--gray-2);
+								color: var(--white);
+							}
+						}
+					}
+				}
+			}
+
+			& .footer {
+				display: none;
+
+				@media (--desktop-viewport) {
+					bottom: 0;
+					display: inline-block;
+					left: 0;
+					position: absolute;
+				}
+
+				& a {
+					align-items: center;
+					color: inherit;
+					display: inline-flex;
+					line-height: 1.75rem;
+					transition: color 0.35s ease;
+
+					&:hover svg {
+						transform: translateX(2px);
+					}
+
+					& + a {
+						margin-left: 50px;
+					}
+				}
+
+				& svg {
+					margin: 2px 0 0 8px;
+					transition: transform 0.35s;
+				}
+			}
+		}
+
+		/* PROMOS */
+		& .promo {
+			background: var(--gray-6);
+			color: inherit;
+			display: none;
+			flex-direction: column;
+			flex-shrink: 0;
+			height: 344px;
+			margin-left: 32px;
+			overflow: hidden;
+			position: relative;
+			width: 280px;
+
+			@media (--desktop-viewport) {
+				display: flex;
+			}
+
+			&:nth-of-type(2) {
+				display: none;
+
+				@media (min-width: 1000px) {
+					display: flex;
+				}
+			}
+
+			&:hover .callout {
+				text-decoration: underline;
+			}
+
+			&.theme-brand {
+				background: var(--brand-secondary);
+			}
+
+			&.theme-consul {
+				background: var(--consul-secondary);
+			}
+
+			&.theme-nomad {
+				background: var(--nomad-secondary);
+			}
+
+			&.theme-packer {
+				background: var(--packer-secondary);
+			}
+
+			&.theme-terraform {
+				background: var(--terraform-secondary);
+			}
+
+			&.theme-vagrant {
+				background: var(--vagrant-secondary);
+			}
+
+			&.theme-vault {
+				background: var(--vault-secondary);
+			}
+
+			& picture {
+				display: block;
+				flex-shrink: 0;
+				line-height: 0;
+			}
+
+			& img {
+				flex-shrink: 0;
+				width: 100%;
+			}
+
+			& .content {
+				display: flex;
+				flex-direction: column;
+				height: 100%;
+				justify-content: space-between;
+				padding: 22px 32px 32px;
+				position: relative;
+			}
+
+			& .title {
+				display: block;
+			}
+
+			& .callout {
+				bottom: 32px;
+				color: inherit;
+				line-height: 1.75rem;
+				position: absolute;
+			}
+		}
+	}
+
+	/* PRICING BUTTON */
+	& .pricing {
+		background: var(--gray-6);
+		bottom: 0;
+		left: 0;
+		padding: 24px;
+		position: fixed;
+		width: 100%;
+
+		@media (--desktop-viewport) {
+			background: none;
+			margin-left: 32px;
+			padding: 0;
+			position: static;
+		}
+
+		& a {
+			border: 1px solid #d2d2d3;
+			border-radius: 4px;
+			box-sizing: border-box;
+			color: inherit;
+			display: block;
+			padding: 7px 22px;
+			text-align: center;
+			text-decoration: none;
+			transition: background-color 0.15s ease, border 0.15s ease;
+			width: 100%;
+
+			@media (--desktop-viewport) {
+				width: auto;
+			}
+
+			&:hover,
+			&:active {
+				text-decoration: none;
+			}
+
+			&:focus,
+			&:hover {
+				background: #e8e8e9;
+				border-color: #e8e8e9;
+			}
+
+			&:active {
+				background: #dbdbdc;
+				border-color: #dbdbdc;
+			}
+		}
+	}
 }

--- a/pages/home/content.mdx
+++ b/pages/home/content.mdx
@@ -7,10 +7,10 @@ The task is to build a "people directory" page. This page should allow visitors 
 Use [this Figma file](https://www.figma.com/file/xGicP4qkXbMhte4LAYxC4X/Untitled?node-id=0%3A1) as your source of truth for design and behavior:
 
 <iframe
-  width="800"
-  height="450"
-  src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FxGicP4qkXbMhte4LAYxC4X%2FUntitled%3Fnode-id%3D0%253A1"
-  allowFullScreen
+	width="800"
+	height="450"
+	src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FxGicP4qkXbMhte4LAYxC4X%2FUntitled%3Fnode-id%3D0%253A1"
+	allowFullScreen
 ></iframe>
 
 There are definitely some parts of this that are a little ambiguous, which is how real world projects always work. Treat this the same way you would if you started working with us and this was your first day — this is quite similar to the type of task we would assign a new hire on their first day. We will set up a Discord channel for you to ask questions, get clarification, and collaborate with us in general, and we strongly encourage you to take advantage of this.
@@ -39,12 +39,12 @@ import rivetQuery from '@hashicorp/platform-cms'
 import query from './query.graphql'
 
 export default function SomePage({ data }) {
-  return <p>{JSON.stringify(data)}</p>
+	return <p>{JSON.stringify(data)}</p>
 }
 
 export async function getStaticProps() {
-  const data = await rivetQuery({ query })
-  return { props: { data } }
+	const data = await rivetQuery({ query })
+	return { props: { data } }
 }
 ```
 

--- a/pages/people/query.graphql
+++ b/pages/people/query.graphql
@@ -6,20 +6,20 @@
 # You may want / need to edit this query!
 
 query {
-  allDepartments(first: 100) {
-    name
-    parent {
-      id
-    }
-  }
+	allDepartments(first: 100) {
+		name
+		parent {
+			id
+		}
+	}
 
-  allPeople(first: 100) {
-    name
-    avatar {
-      url
-    }
-    department {
-      name
-    }
-  }
+	allPeople(first: 100) {
+		name
+		avatar {
+			url
+		}
+		department {
+			name
+		}
+	}
 }

--- a/pages/people/style.module.css
+++ b/pages/people/style.module.css
@@ -5,7 +5,7 @@
 /* ref: https://preset-env.cssdb.org/ */
 
 .myData {
-  color: yellow;
-  background-color: var(--black);
-  padding: 16px;
+	color: yellow;
+	background-color: var(--black);
+	padding: 16px;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+	"compilerOptions": {
+		"baseUrl": ".",
+		"target": "es5",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": false,
+		"forceConsistentCasingInFileNames": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "node",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "preserve",
+		"incremental": true
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR runs prettier (via `npm run format`) so that candidates who use Prettier-enabled editors don't have unnecessarily large diffs when prettier applies the spaces-to-tabs conversion.
